### PR TITLE
Fix Callback.razor Supabase.Client injection after backend separation

### DIFF
--- a/PF2EGM/Components/Pages/Auth/Callback.razor
+++ b/PF2EGM/Components/Pages/Auth/Callback.razor
@@ -1,23 +1,24 @@
 @page "/auth/callback"
-@inject Supabase.Client Supabase
+@using PF2EGM.Services
+@inject IApiAuthService AuthService
 @inject NavigationManager Nav
- 
+
 <p>Signing you in...</p>
 
 @code {
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
- 
+
         var uri  = new Uri(Nav.Uri);
         var frag = Microsoft.AspNetCore.WebUtilities.QueryHelpers
                      .ParseQuery(uri.Fragment.TrimStart('#'));
- 
+
         if (frag.TryGetValue("access_token",  out var at) &&
             frag.TryGetValue("refresh_token", out var rt))
         {
-            await Supabase.Auth.SetSession(at!, rt!);
-            Nav.NavigateTo("/");
+            var result = await AuthService.SetSessionAsync(at!, rt!);
+            Nav.NavigateTo(result.IsSuccess ? "/" : "/login?error=oauth_failed");
         }
         else
         {

--- a/PF2EGM/Services/ApiAuthService.cs
+++ b/PF2EGM/Services/ApiAuthService.cs
@@ -9,6 +9,7 @@ public interface IApiAuthService
     Task SignOutAsync();
     Task<string> GetOAuthUrlAsync(string provider);
     Task<bool> IsAuthenticatedAsync();
+    Task<AuthResult> SetSessionAsync(string accessToken, string refreshToken);
 }
 
 public record AuthResult(bool IsSuccess, string? ErrorMessage = null);
@@ -97,6 +98,24 @@ public class ApiAuthService : IApiAuthService
         {
             _logger.LogError(ex, "Auth status request failed");
             return false;
+        }
+    }
+
+    public async Task<AuthResult> SetSessionAsync(string accessToken, string refreshToken)
+    {
+        try
+        {
+            var response = await _http.PostAsJsonAsync("api/auth/session",
+                new { accessToken, refreshToken });
+            var result = await response.Content.ReadFromJsonAsync<ApiAuthResponse>();
+            return result is not null
+                ? new AuthResult(result.IsSuccess, result.ErrorMessage)
+                : new AuthResult(false, "Unexpected response from server.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Set session request failed");
+            return new AuthResult(false, "Could not establish session.");
         }
     }
 

--- a/Roll-Call Backend/Controllers/AuthController.cs
+++ b/Roll-Call Backend/Controllers/AuthController.cs
@@ -52,7 +52,18 @@ public class AuthController : ControllerBase
         var isAuthenticated = await _authService.IsAuthenticatedAsync();
         return Ok(new { isAuthenticated });
     }
+
+    [HttpPost("session")]
+    public async Task<IActionResult> SetSession([FromBody] SessionRequest request)
+    {
+        var result = await _authService.SetSessionAsync(request.AccessToken, request.RefreshToken);
+        return result.IsSuccess
+            ? Ok(new AuthResponse(true, null))
+            : BadRequest(new AuthResponse(false, result.ErrorMessage));
+    }
 }
+
+public record SessionRequest(string AccessToken, string RefreshToken);
 
 public record AuthRequest(string Email, string Password);
 public record AuthResponse(bool IsSuccess, string? ErrorMessage);

--- a/Roll-Call Backend/Services/SupabaseAuthService.cs
+++ b/Roll-Call Backend/Services/SupabaseAuthService.cs
@@ -11,6 +11,7 @@ public interface ISupabaseAuthService
     Task SignOutAsync();
     Task<string> GetOAuthUrlAsync(string provider, string redirectTo);
     Task<bool> IsAuthenticatedAsync();
+    Task<AuthResult> SetSessionAsync(string accessToken, string refreshToken);
 }
 
 public record AuthResult(bool IsSuccess, string? ErrorMessage = null);
@@ -75,6 +76,20 @@ public class SupabaseAuthService : ISupabaseAuthService
     {
         var session = _client.Auth.CurrentSession;
         return session?.User is not null && session.ExpiresAt() > DateTime.UtcNow;
+    }
+
+    public async Task<AuthResult> SetSessionAsync(string accessToken, string refreshToken)
+    {
+        try
+        {
+            await _client.Auth.SetSession(accessToken, refreshToken);
+            return new AuthResult(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set OAuth session");
+            return new AuthResult(false, "Failed to establish session.");
+        }
     }
 
     private static string FriendlyError(string raw) => raw.ToLower() switch


### PR DESCRIPTION
Replace direct Supabase.Client injection in Callback.razor with IApiAuthService. Add SetSessionAsync to the service interface, ApiAuthService (HTTP call), and the backend SupabaseAuthService + AuthController (POST /api/auth/session).

https://claude.ai/code/session_01FEvhyG8z9JaPS8TokyXXEg