### PR TITLE
Readded Tailwind CDN

### DIFF
--- a/PF2EGM/Components/App.razor
+++ b/PF2EGM/Components/App.razor
@@ -8,6 +8,7 @@
     <ResourcePreloader/>
     <link rel="stylesheet" href="app.built.css" />
     <link rel="stylesheet" href="@Assets["PF2EGM.styles.css"]"/>
+    <script src="https://cdn.tailwindcss.com"></script>
     <ImportMap/>
     <link rel="icon" type="image/png" href="favicon.png"/>
     <HeadOutlet @rendermode="InteractiveServer"/>


### PR DESCRIPTION
Readded Tailwind CDN temporarily so Lumex doesn't overwrite Tailwind classes. Tailwind classes were previously not being applied in CSS. Hoping for more permanent fix using local Tailwind instance.